### PR TITLE
Add docker registry

### DIFF
--- a/node_fileserver.tf
+++ b/node_fileserver.tf
@@ -38,6 +38,14 @@ resource "openstack_compute_volume_attach_v2" "registry-vol" {
   volume_id   = "${openstack_blockstorage_volume_v2.registry-vol.id}"
 }
 
+output "Registry device" {
+  value = "${openstack_compute_volume_attach_v2.registry-vol.device}"
+}
+
+output "Home device" {
+  value = "${openstack_compute_volume_attach_v2.homes-vol.device}"
+}
+
 resource "null_resource" "provision_fileserver" {
   depends_on = ["openstack_compute_floatingip_associate_v2.fip_fileserver", "null_resource.provision_master", "openstack_compute_volume_attach_v2.homes-vol", "openstack_compute_volume_attach_v2.registry-vol"]
   connection {
@@ -82,10 +90,18 @@ resource "null_resource" "provision_fileserver" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /home/core/wholetale/nfs-init.sh",
-      "sudo /home/core/wholetale/nfs-init.sh -v -d /dev/vdb -m /mnt -e /share -c ${openstack_networking_subnet_v2.ext_net_subnet.cidr}"
+      "sudo /home/core/wholetale/nfs-init.sh -v -d ${openstack_compute_volume_attach_v2.registry-vol.device} -m /mnt/registry -e /share -c ${openstack_networking_subnet_v2.ext_net_subnet.cidr}",
+      "sudo /home/core/wholetale/nfs-init.sh -v -d ${openstack_compute_volume_attach_v2.homes-vol.device} -m /mnt/homes -e /share -c ${openstack_networking_subnet_v2.ext_net_subnet.cidr}",
     ]
   }
 
+  provisioner "remote-exec" {
+    inline = [
+      "docker pull registry:2.6",
+      "sudo mkdir -p /mnt/registry/auth",
+      "docker run --rm --entrypoint htpasswd registry:2.6 -Bbn ${var.registry_user} ${var.registry_pass} | sudo tee /mnt/registry/auth/registry.password > /dev/null"
+    ]
+  }
 
 #  provisioner "remote-exec" {
 #    inline = ["sudo umount -A"]

--- a/scripts/nfs-init.sh
+++ b/scripts/nfs-init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 device=""
-mount_path=""
+mount_path=""   # assumes /mnt/<name> TODO: Add sanity check
 export_path=""
 cidr_range=""
 verbose=0
@@ -81,7 +81,7 @@ if [ ! -d ${mount_path} ]; then
 fi
 
 # Create systemd mount file
-cat << EOF >  /etc/systemd/system/mnt.mount
+cat << EOF >  /etc/systemd/system/mnt-${mount_path#/mnt/}.mount
 [Unit]
 Description=Mount $device on $mount_path
 After=local-fs.target
@@ -96,13 +96,15 @@ Options=noatime
 WantedBy=multi-user.target
 EOF
 
+# Enable mount file
+systemctl enable mnt-${mount_path#/mnt/}.mount
 
 # Mount device to specified path
 if  ! mount | grep "^${device} " > /dev/null ; then
    if [ $verbose ]; then
       echo "Mounting ${device} to ${mount_path}"
    fi
-   systemctl start mnt.mount
+   systemctl start mnt-${mount_path#/mnt/}.mount
 else
    echo "${device} already mounted"
 fi

--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -2,6 +2,8 @@
 
 domain=$1 
 role=$2
+registry_user=$3
+registry_pass=$4
 
 sudo umount /usr/local/lib > /dev/null 2>&1 || true
 docker stop celery_worker >/dev/null 2>&1
@@ -15,9 +17,9 @@ docker run \
     -e GIRDER_API_URL=https://girder.${domain}/api/v1 \
     -e HOSTDIR=/host \
     -e TRAEFIK_NETWORK=wt_traefik-net \
-    -e REGISTRY_USER=TODO_SET_ME \
+    -e REGISTRY_USER=${registry_user} \
     -e REGISTRY_URL=https://registry.${domain} \
-    -e REGISTRY_PASS=TODO_USE_VARIABLE \
+    -e REGISTRY_PASS=${registry_pass} \
     -v /var/run/docker.sock:/var/run/docker.sock:ro \
     -v /:/host \
     -v /var/cache/davfs2:/var/cache/davfs2 \

--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -15,6 +15,9 @@ docker run \
     -e GIRDER_API_URL=https://girder.${domain}/api/v1 \
     -e HOSTDIR=/host \
     -e TRAEFIK_NETWORK=wt_traefik-net \
+    -e REGISTRY_USER=TODO_SET_ME \
+    -e REGISTRY_URL=https://registry.${domain} \
+    -e REGISTRY_PASS=TODO_USE_VARIABLE \
     -v /var/run/docker.sock:/var/run/docker.sock:ro \
     -v /:/host \
     -v /var/cache/davfs2:/var/cache/davfs2 \

--- a/stack.tf
+++ b/stack.tf
@@ -101,7 +101,7 @@ resource "null_resource" "deploy_stack" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /home/core/wholetale/start-worker.sh",
-      "/home/core/wholetale/start-worker.sh ${var.domain} manager"
+      "/home/core/wholetale/start-worker.sh ${var.domain} manager ${var.registry_user} ${var.registry_pass}"
     ]
   }
 }
@@ -130,7 +130,7 @@ resource "null_resource" "start_worker" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /home/core/wholetale/start-worker.sh",
-      "/home/core/wholetale/start-worker.sh ${var.domain} celery"
+      "/home/core/wholetale/start-worker.sh ${var.domain} celery ${var.registry_user} ${var.registry_pass}"
     ]
   }
 }

--- a/stacks/core/swarm-compose.tpl
+++ b/stacks/core/swarm-compose.tpl
@@ -99,10 +99,10 @@ services:
     image: redis
     networks:
       - celery
-    labels:
-      - "traefik.enable: false"
     deploy:
       replicas: 1
+    	labels:
+      	- "traefik.enable=false"
 
   dashboard:
     image: wholetale/dashboard:stable
@@ -119,3 +119,27 @@ services:
         - "traefik.docker.network=wt_traefik-net"
         - "traefik.frontend.passHostHeader=true"
         - "traefik.frontend.entryPoints=https"
+
+  registry:
+    image: registry:2.6
+    networks:
+      - traefik-net
+    volumes:
+      - "/mnt/registry:/var/lib/registry"
+      - "/mnt/registry/auth:/auth:ro"
+    environment:
+      - REGISTRY_AUTH=htpasswd
+      - REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm"
+      - REGISTRY_AUTH_HTPASSWD_PATH=/auth/registry.password
+    deploy:
+      replicas: 1
+      labels:
+        - "traefik.enable=true"
+        - "traefik.port=5000"
+        - "traefik.frontend.rule=Host:registry.${domain}"
+        - "traefik.docker.network=wt_traefik-net"
+        - "traefik.frontend.passHostHeader=true"
+        - "traefik.frontend.entryPoints=https"
+      placement:
+        constraints:
+          - node.labels.storage == 1

--- a/stacks/core/swarm-compose.tpl
+++ b/stacks/core/swarm-compose.tpl
@@ -101,8 +101,8 @@ services:
       - celery
     deploy:
       replicas: 1
-    	labels:
-      	- "traefik.enable=false"
+      labels:
+        - "traefik.enable=false"
 
   dashboard:
     image: wholetale/dashboard:stable

--- a/variables.tf
+++ b/variables.tf
@@ -71,3 +71,13 @@ variable "nfs_volume_size" {
     default =  40
     description = "Fileserver volume size in GB"
 }
+
+variable "registry_user" {
+    default = "fido"
+    description = "Default user used in the internal docker registry"
+}
+
+variable "registry_pass" {
+    default = "10DSObv0Awqaa8Wz4d3K"
+    description = "Random password for the user used in the internal docker registry"
+}


### PR DESCRIPTION
This PR adds docker registry to the Whole Tale stack. It includes:

 * mounting both block devices into proper paths (`/mnt/homes` and `/mnt/registry`)
 * generating default registry user (`vars.registry_user/pass`) credentials file
 * passing aforementioned credentials to celery worker

In order to test:

1. deploy
2. `docker login https://registry.${domain}` (use `vars.user/pass`)
3. `docker push <image>`
4. `docker pull <image>`
5. (optionally) Try entire WT flow (adding recipe/image, building image, creating/running Tale).