### PR TITLE
Multiple deployment support

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -1,19 +1,19 @@
 resource "openstack_networking_network_v2" "ext_network" {
-  name = "WT-external"
+  name = "${var.cluster_name}-external"
   admin_state_up = "true"
 }
 
 resource "openstack_networking_subnet_v2"  "ext_net_subnet" {
-  name       = "WT-external_subnet"
+  name       = "${var.cluster_name}-external_subnet"
   network_id = "${openstack_networking_network_v2.ext_network.id}"
   cidr       = "192.168.99.0/24"
   ip_version = 4
   enable_dhcp = "true"
-  dns_nameservers = ["141.142.2.2","141.142.230.144"]
+  dns_nameservers = ["8.8.8.8", "8.8.8.4"]
 }
 
 resource "openstack_networking_router_v2" "ext_router" {
-  name = "WT_ext_router"
+  name = "${var.cluster_name}_ext_router"
   admin_state_up = "true"
   external_gateway = "${var.external_gateway}"
 }
@@ -24,16 +24,16 @@ resource "openstack_networking_router_interface_v2" "ext_router_interface" {
 }
 
 resource "openstack_networking_network_v2" "int_network" {
-  name = "WT-mgmt"
+  name = "${var.cluster_name}-mgmt"
   admin_state_up = "true"
 }
 
 resource "openstack_networking_subnet_v2"  "int_net_subnet" {
-  name       = "WT-internal_subnet"
+  name       = "${var.cluster_name}-internal_subnet"
   network_id = "${openstack_networking_network_v2.int_network.id}"
   cidr       = "192.168.149.0/24"
   ip_version = 4
   enable_dhcp = "true"
   no_gateway = "true"
-  dns_nameservers = ["141.142.2.2","141.142.230.144"]
+  dns_nameservers = ["8.8.8.8", "8.8.8.4"]
 }

--- a/network.tf
+++ b/network.tf
@@ -6,7 +6,7 @@ resource "openstack_networking_network_v2" "ext_network" {
 resource "openstack_networking_subnet_v2"  "ext_net_subnet" {
   name       = "${var.cluster_name}-external_subnet"
   network_id = "${openstack_networking_network_v2.ext_network.id}"
-  cidr       = "192.168.99.0/24"
+  cidr       = "${var.external_subnet}"
   ip_version = 4
   enable_dhcp = "true"
   dns_nameservers = ["8.8.8.8", "8.8.8.4"]
@@ -31,7 +31,7 @@ resource "openstack_networking_network_v2" "int_network" {
 resource "openstack_networking_subnet_v2"  "int_net_subnet" {
   name       = "${var.cluster_name}-internal_subnet"
   network_id = "${openstack_networking_network_v2.int_network.id}"
-  cidr       = "192.168.149.0/24"
+  cidr       = "${var.internal_subnet}"
   ip_version = 4
   enable_dhcp = "true"
   no_gateway = "true"

--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -5,11 +5,13 @@ role=$2
 registry_user=$3
 registry_pass=$4
 
+image=wholetale/gwvolman:stable
+
 sudo umount /usr/local/lib > /dev/null 2>&1 || true
 docker stop celery_worker >/dev/null 2>&1
 docker rm celery_worker > /dev/null 2>&1 
 
-docker pull wholetale/gwvolman:dev > /dev/null 2>&1
+docker pull ${image} > /dev/null 2>&1
 
 docker run \
     --name celery_worker \
@@ -28,15 +30,9 @@ docker run \
     --cap-add SYS_ADMIN \
     --cap-add SYS_PTRACE \
     --network wt_celery \
-    -d --entrypoint=/usr/bin/python \
-    wholetale/gwvolman:dev \
-      -m girder_worker -l info \
+    -d ${image} \
       -Q ${role},$(docker info --format "{{.Swarm.NodeID}}") \
       --hostname=$(docker info --format "{{.Swarm.NodeID}}")
-
-sudo mount --bind \
-  $(docker inspect --format={{.GraphDriver.Data.MergedDir}} celery_worker)/usr/local/lib \
-  /usr/local/lib
 
 docker exec -ti celery_worker chown davfs2:davfs2 /host/run/mount.davfs
 docker exec -ti celery_worker chown davfs2:davfs2 /host/var/cache/davfs2

--- a/security_master.tf
+++ b/security_master.tf
@@ -1,5 +1,5 @@
 resource "openstack_networking_secgroup_v2" "wt_master" {
-  name = "WT Master Node"
+  name = "${var.cluster_name} Master Node"
   description = "HTTP/HTTPS access for main node"
 }
 

--- a/security_slave.tf
+++ b/security_slave.tf
@@ -1,5 +1,5 @@
 resource "openstack_networking_secgroup_v2" "wt_node" {
-  name = "WT Node defaults"
+  name = "${var.cluster_name} Node defaults"
   description = "Default set of networking rules for WT Node"
 }
 

--- a/user.tf
+++ b/user.tf
@@ -1,4 +1,4 @@
 resource "openstack_compute_keypair_v2" "ssh_key" {
-  name = "SSH keypair for Terraform instances"
+  name = "${var.cluster_name}"
   public_key = "${file("${var.ssh_key_file}.pub")}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,16 @@ variable "pool" {
     description = "Network pool for assigning floating_ips"
 }
 
+variable "external_subnet" {
+    default = "192.168.99.0/24"
+    description = "Default subnet for external network"
+}
+
+variable "internal_subnet" {
+    default = "192.168.149.0/24"
+    description = "Default subnet for external network"
+}
+
 variable "cluster_name" {
     default = "wt-dev"
     description = "Cluster name"


### PR DESCRIPTION
This PR fixes #16 

Changes:
* Changed DNS to Google (this could be parameterized, if preferred)
* Parameterized network and SSH key names
* Parameterized subnets

To test:
* Deploy two separate WT instances in the same OpenStack project