### PR TITLE
Godaddy integration and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ These are detailed below, but in short:
 * Wildcard DNS for your domain
 * [Globus Auth client ID and secret](https://auth.globus.org/v2/web/developers)
 * rclone binary 
+* n3integrate GoDaddy Terraform plugin
 
 
 ## OpenStack
@@ -73,6 +74,23 @@ token = {"access_token":"<token>","token_type":"bearer","refresh_token":"<token>
 ```
 
 Rclone is used by the `wholetale/backup` container to backup and restore home directories and Mongo using Box.
+
+## GoDaddy API Integration
+
+The deployment process uses the [n3integrate plugin](https://github.com/n3integration/terraform-godaddy).
+
+```
+bash <(curl -s https://raw.githubusercontent.com/n3integration/terraform-godaddy/master/install.sh)
+```
+
+This requires that you setup an API key via the [GoDaddy developer interface](https://developer.godaddy.com/keys).
+
+Set the API key and secret environment variables prior to running  `terraform apply`.
+
+```
+export GODADDY_API_KEY=abc
+export GODADDY_API_SECRET=123
+```
 
 ## Terraform variables
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These are detailed below, but in short:
 * Wildcard DNS for your domain
 * [Globus Auth client ID and secret](https://auth.globus.org/v2/web/developers)
 * rclone binary 
-* n3integrate GoDaddy Terraform plugin
+* GoDaddy API integration
 
 
 ## OpenStack
@@ -77,20 +77,7 @@ Rclone is used by the `wholetale/backup` container to backup and restore home di
 
 ## GoDaddy API Integration
 
-The deployment process uses the [n3integrate plugin](https://github.com/n3integration/terraform-godaddy).
-
-```
-bash <(curl -s https://raw.githubusercontent.com/n3integration/terraform-godaddy/master/install.sh)
-```
-
-This requires that you setup an API key via the [GoDaddy developer interface](https://developer.godaddy.com/keys).
-
-Set the API key and secret environment variables prior to running  `terraform apply`.
-
-```
-export GODADDY_API_KEY=abc
-export GODADDY_API_SECRET=123
-```
+The deployment process uses the GoDaddy API to automatically create DNS entries for non-production deployments and for wildcard certificate generation.
 
 ## Terraform variables
 
@@ -106,7 +93,8 @@ The ``variables.tf`` file contains variables used during the deployment process.
 * globus_client_id: Globus auth client ID
 * globus_client_secret: Globus auth client secret
 * docker_mtu: Docker MTU for  OpenStack
-* restore_url: Mongo DB restore URL
+* godaddy_api_key:  GoDaddy API key
+* godaddy_api_secret: GoDaddy API secret
 
 ## Terraform deployment
 

--- a/assets/traefik/traefik.tpl
+++ b/assets/traefik/traefik.tpl
@@ -1,13 +1,13 @@
 graceTimeOut = "10s"
 debug = false
 checkNewVersion = false
-logLevel = "WARN"
+logLevel = "INFO"
 
 # If set to true invalid SSL certificates are accepted for backends.
 # Note: This disables detection of man-in-the-middle attacks so should only be used on secure backend networks.
 # Optional
 # Default: false
-# 
+#
 # InsecureSkipVerify = true
 
 defaultEntryPoints = ["http", "https"]
@@ -15,31 +15,41 @@ defaultEntryPoints = ["http", "https"]
 [entryPoints]
   [entryPoints.http]
   address = ":80"
+    [entryPoints.http.redirect]
+    entryPoint = "https"
   [entryPoints.https]
   address = ":443"
-  [entryPoints.https.tls]
+    [entryPoints.https.tls]
+    #MinVersion = "VersionTLS12"
+    #CipherSuites = ["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"]
+    MinVersion = "VersionTLS10"
+    CipherSuites = ["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"]
 
 [acme]
 email = "bgates@microsoft.com"   # FIXME
 storage = "/acme/acme.json"
 entryPoint = "https"
 acmeLogging = true
-onDemand = true
-# Enable certificate generation on frontends Host rules. This will request a certificate from Let's Encrypt for each frontend with a Host rule.
-# For example, a rule Host:test1.traefik.io,test2.traefik.io will request a certificate with main domain test1.traefik.io and SAN test2.traefik.io.
-#
-# Optional
-#
-# OnHostRule = true
-# caServer = "https://acme-staging.api.letsencrypt.org/directory"
+
+[acme.httpChallenge]
+entryPoint = "http"
+
+[acme.dnsChallenge]
+provider = "godaddy"
+delayBeforeCheck = 0
+
+[[acme.domains]]
+main = "*.${subdomain}.${domain}"
+
+[[acme.domains]]
+main = "dashboard-${subdomain}.${domain}"
 
 [web]
 address = ":8080"
 
-  
 [docker]
 endpoint = "unix:///var/run/docker.sock"
-domain = "${domain}"
+domain = "${subdomain}.${domain}"
 watch = true
 exposedbydefault = true
 swarmmode = true

--- a/dns.tf
+++ b/dns.tf
@@ -2,7 +2,7 @@ resource "null_resource" "update_dns" {
   depends_on = ["openstack_compute_floatingip_associate_v2.fip_master"]
 
   provisioner "local-exec" {
-    command = "docker run -v `pwd`/scripts:/scripts craigwillis/wt-python python scripts/godaddy-update-dns.py -k ${var.godaddy_api_key} -s ${var.godaddy_api_secret} -d ${var.domain} -n ${var.subdomain} -a ${openstack_networking_floatingip_v2.swarm_master_ip.address}"
+    command = "docker run -v `pwd`/scripts:/scripts jfloff/alpine-python:2.7-slim -p requests -- python scripts/godaddy-update-dns.py -k ${var.godaddy_api_key} -s ${var.godaddy_api_secret} -d ${var.domain} -n ${var.subdomain} -a ${openstack_networking_floatingip_v2.swarm_master_ip.address}"
   }
 
 }

--- a/dns.tf
+++ b/dns.tf
@@ -1,0 +1,8 @@
+resource "null_resource" "update_dns" {
+  depends_on = ["openstack_compute_floatingip_associate_v2.fip_master"]
+
+  provisioner "local-exec" {
+    command = "docker run -v `pwd`/scripts:/scripts craigwillis/wt-python python scripts/godaddy-update-dns.py -k ${var.godaddy_api_key} -s ${var.godaddy_api_secret} -d ${var.domain} -n ${var.subdomain} -a ${openstack_networking_floatingip_v2.swarm_master_ip.address}"
+  }
+
+}

--- a/scripts/godaddy-update-dns.py
+++ b/scripts/godaddy-update-dns.py
@@ -1,0 +1,79 @@
+#!/bin/python
+import argparse
+import json
+import requests
+
+#
+# Simple CLI to create/update DNS A record in GoDaddy
+#
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument("-k", "--key", required=True, help="Godaddy API key")
+parser.add_argument("-s", "--secret", required=True, help="Godaddy API secret")
+parser.add_argument("-d", "--domain", required=True, help="Domain name")
+parser.add_argument("-n", "--name", required=True, help="DNS A record entry name")
+parser.add_argument("-a", "--address", required=True, help="DNS A record ip address value")
+
+
+args = parser.parse_args()
+
+# Uses the records and A record enpoints
+baseUrl = "https://api.godaddy.com/v1"
+recordsUrl = "%s/domains/%s/records" % (baseUrl, args.domain)
+recordUrl = "%s/A/*.%s" % (recordsUrl, args.name)
+
+# Authentication requires GoDaddy API key and secret
+authHeader = "sso-key %s:%s" % (args.key, args.secret)
+
+# DNS A record
+wildcard_record = [{
+    'data': args.address,
+    'name': "*." + args.name,
+    'ttl': 600,
+    'type': 'A'
+}]
+
+try:
+
+    # Get the record for this name
+    r = requests.get(recordUrl, headers={'Authorization': authHeader})
+
+    # Endpoint should return 200 whether record exists or not
+    if r.status_code == requests.codes.ok:
+
+        body = r.json()
+
+        if not body:
+            #  If body is empty, no existing A record exists so created it using the PATCH method
+            print("No record found for *.%s, creating" % args.name)
+
+            r = requests.patch(recordsUrl, json=wildcard_record, headers={'Authorization': authHeader, 'accept': 'application/json'})
+            if r.status_code == requests.codes.ok:
+                print("Record successfully created")
+            else:
+                print("Error: Failed to create record: %s" % r.status_code)
+
+        else:
+            #  If body is not empty, confirm that it differs from the specified information and update if needed
+            if body == wildcard_record:
+                print("Record found, but configuration unchanged")
+            else:
+                print("Record found for %s, updating" % args.name)
+                r = requests.put(recordUrl, json=wildcard_record, headers={'Authorization': authHeader, 'accept': 'application/json'})
+
+                if r.status_code == requests.codes.ok:
+                    print("Record successfully updated")
+                else:
+                    print("Error: Failed to create: %s" % r.status_code)
+
+        # Get the final record and con  firm it matches what was supplied
+        r = requests.get(recordUrl, headers={'Authorization': authHeader})
+
+        print(json.dumps(r.json(), indent=4, sort_keys=True))
+
+    else:
+        r.raise_for_status()
+
+except requests.exceptions.RequestException as e:
+    print(e)

--- a/scripts/pre-setup-all.sh
+++ b/scripts/pre-setup-all.sh
@@ -11,3 +11,13 @@ docker network create \
   --opt com.docker.network.bridge.enable_ip_masquerade=true \
   --opt com.docker.network.driver.mtu=${mtu} \
   docker_gwbridge
+
+
+# Set the maximum journal size
+cat << EOF > /etc/systemd/journald.conf 
+[Journal]
+SystemMaxUse=500M
+EOF
+
+sudo systemctl reload systemd-journald
+systemctl restart systemd-journald

--- a/scripts/pre-setup-all.sh
+++ b/scripts/pre-setup-all.sh
@@ -14,10 +14,10 @@ docker network create \
 
 
 # Set the maximum journal size
-cat << EOF > /etc/systemd/journald.conf 
+sudo cat << EOF > /etc/systemd/journald.conf 
 [Journal]
 SystemMaxUse=500M
 EOF
 
 sudo systemctl reload systemd-journald
-systemctl restart systemd-journald
+sudo systemctl restart systemd-journald

--- a/stack.tf
+++ b/stack.tf
@@ -20,7 +20,7 @@ data "template_file" "stack" {
 }
 
 resource "null_resource" "label_nodes" {
-  depends_on = ["null_resource.provision_slave"]
+  depends_on = ["null_resource.provision_slave", "null_resource.provision_fileserver"]
 
   connection {
     user = "${var.ssh_user_name}"

--- a/stack.tf
+++ b/stack.tf
@@ -39,7 +39,7 @@ resource "null_resource" "label_nodes" {
 }
 
 resource "null_resource" "deploy_stack" {
-  depends_on = ["null_resource.label_nodes"]
+  depends_on = ["null_resource.label_nodes", "null_resource.provision_fileserver"]
 
   connection {
     user = "${var.ssh_user_name}"

--- a/stack.tf
+++ b/stack.tf
@@ -3,6 +3,7 @@ data "template_file" "traefik" {
 
   vars {
     domain = "${var.domain}"
+    subdomain = "${var.subdomain}"
   }
 }
 
@@ -11,7 +12,10 @@ data "template_file" "stack" {
 
   vars {
     domain = "${var.domain}"
+    subdomain = "${var.subdomain}"
     mtu = "${var.docker_mtu}"
+    godaddy_api_key = "${var.godaddy_api_key}"
+    godaddy_api_secret = "${var.godaddy_api_secret}"
   }
 }
 
@@ -86,6 +90,8 @@ resource "null_resource" "deploy_stack" {
   provisioner "remote-exec" {
     inline = [
       "chmod 600 /home/core/wholetale/traefik/acme/acme.json",
+      "sed -i 's/dashboard\.prod/dashboard/g' /home/core/wholetale/swarm-compose.yaml",
+      "sed -i 's/dashboard-prod/dashboard/g' /home/core/wholetale/traefik/traefik.toml",
       "docker stack deploy --compose-file /home/core/wholetale/swarm-compose.yaml wt",
       "docker stack deploy --compose-file /home/core/wholetale/monitoring.yaml omd"
     ]
@@ -94,14 +100,14 @@ resource "null_resource" "deploy_stack" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /home/core/wholetale/init-mongo.sh",
-      "/home/core/wholetale/init-mongo.sh ${var.domain} ${var.globus_client_id} ${var.globus_client_secret}"
+      "/home/core/wholetale/init-mongo.sh ${var.subdomain}.${var.domain} ${var.globus_client_id} ${var.globus_client_secret}"
     ]
   }
 
   provisioner "remote-exec" {
     inline = [
       "chmod +x /home/core/wholetale/start-worker.sh",
-      "/home/core/wholetale/start-worker.sh ${var.domain} manager ${var.registry_user} ${var.registry_pass}"
+      "/home/core/wholetale/start-worker.sh ${var.subdomain}.${var.domain} manager ${var.registry_user} ${var.registry_pass}"
     ]
   }
 }
@@ -130,7 +136,7 @@ resource "null_resource" "start_worker" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /home/core/wholetale/start-worker.sh",
-      "/home/core/wholetale/start-worker.sh ${var.domain} celery ${var.registry_user} ${var.registry_pass}"
+      "/home/core/wholetale/start-worker.sh ${var.subdomain}.${var.domain} celery ${var.registry_user} ${var.registry_pass}"
     ]
   }
 }

--- a/stack.tf
+++ b/stack.tf
@@ -90,7 +90,7 @@ resource "null_resource" "deploy_stack" {
   provisioner "remote-exec" {
     inline = [
       "chmod 600 /home/core/wholetale/traefik/acme/acme.json",
-      "sed -i 's/dashboard\.prod/dashboard/g' /home/core/wholetale/swarm-compose.yaml",
+      "sed -i 's/dashboard\\.prod/dashboard/g' /home/core/wholetale/swarm-compose.yaml",
       "sed -i 's/dashboard-prod/dashboard/g' /home/core/wholetale/traefik/traefik.toml",
       "docker stack deploy --compose-file /home/core/wholetale/swarm-compose.yaml wt",
       "docker stack deploy --compose-file /home/core/wholetale/monitoring.yaml omd"

--- a/stacks/core/swarm-compose.tpl
+++ b/stacks/core/swarm-compose.tpl
@@ -84,10 +84,13 @@ services:
       - celery
       - traefik-net
       - mongo
+    environment:
+      - GODADDY_API_KEY=${godaddy_api_key}
+      - GODADDY_API_SECRET=${godaddy_api_secret}
     deploy:
       replicas: 1
       labels:
-        - "traefik.frontend.rule=Host:girder.${domain}"
+        - "traefik.frontend.rule=Host:girder.${subdomain}.${domain}"
         - "traefik.port=8080"
         - "traefik.enable=true"
         - "traefik.docker.network=wt_traefik-net"
@@ -110,12 +113,12 @@ services:
     networks:
       - traefik-net
     environment:
-      - GIRDER_API_URL=https://girder.${domain}
+      - GIRDER_API_URL=https://girder.${subdomain}.${domain}
     deploy:
       replicas: 1
       labels:
         - "traefik.port=80"
-        - "traefik.frontend.rule=Host:dashboard.${domain}"
+        - "traefik.frontend.rule=Host:dashboard.${subdomain}.${domain}"
         - "traefik.enable=true"
         - "traefik.docker.network=wt_traefik-net"
         - "traefik.frontend.passHostHeader=true"

--- a/stacks/core/swarm-compose.tpl
+++ b/stacks/core/swarm-compose.tpl
@@ -33,6 +33,9 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - "/home/core/wholetale/traefik:/etc/traefik"
       - "/home/core/wholetale/traefik/acme:/acme"
+    environment:
+      - GODADDY_API_KEY=${godaddy_api_key}
+      - GODADDY_API_SECRET=${godaddy_api_secret}
     deploy:
       replicas: 1
       placement:
@@ -84,9 +87,6 @@ services:
       - celery
       - traefik-net
       - mongo
-    environment:
-      - GODADDY_API_KEY=${godaddy_api_key}
-      - GODADDY_API_SECRET=${godaddy_api_secret}
     deploy:
       replicas: 1
       labels:

--- a/variables.tf
+++ b/variables.tf
@@ -8,7 +8,7 @@ variable "image" {
 }
 
 variable "flavor" {
-    default = "m1.small"
+    default = "m1.medium"
     description = "openstack flavor list : Name"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,11 @@ variable "domain" {
     description = "Site domain name"
 }
 
+variable "subdomain" {
+    default = "dev"
+    description = "Site subdomain name"
+}
+
 variable "globus_client_id" {
     default = ""
     description = "Globus client ID"
@@ -85,4 +90,14 @@ variable "registry_user" {
 variable "registry_pass" {
     default = "10DSObv0Awqaa8Wz4d3K"
     description = "Random password for the user used in the internal docker registry"
+}
+
+variable "godaddy_api_key" {
+   default = ""
+   description = "API key for GoDaddy DNS"
+}
+
+variable "godaddy_api_secret" {
+   default = ""
+   description = "API secret for GoDaddy DNS"
 }


### PR DESCRIPTION
This PR fixes multiple bugs in the terraform process and implements GoDaddy integration for DNS and wildcard cert generation.
* Fixes #9 (change default flavor)
* Fixes #10 (dependency change)
* Fixes #18 (Godaddy DNS integration)
* Partial implementation for girder_wholetale/issues/59 (wildcard support in traefik)

**Test case**
Preconditions:
* Valid rclone config (rclone --config rclone.conf config)
* Configure Globus and GoDaddy API key/secret in variables.tf
* Configure subdomain (e.g., "test")

Confirm #10 and #9:
* View `stack.tf`, confirm `deploy_stack` depends on `provision_fileserver`
* View `variables.tf`, confirm default flavor is m1.medium

Provision the cluster:
`terraform apply`

Restore the development database on fileserver:
```
ssh <nfs node>
docker run -it --network wt_mongo -v /mnt/home:/backup -v /home/core/rclone/:/conf wholetale/backup bash
restore.sh -c dev -d 20180416
init-mongo.sh <subdomain>.wholetale.org <globus_key> <globus_secret>
```

Restart Girder on master:
```
docker service  scale wt_girder=0
docker service  scale wt_girder=1
```

Confirm #18:
* Go to GoDaddy DNS management interface, confirm A record exists and points to correct IP address
* Open browser to https://dashboard.subdomain.wholetale.org

Confirm girder_wholetale/issues/59:
* Go to https://dashboard.subdomain.wholetale.org
* View certificate, should be for *.subdomain.wholetale.org and issued by Let's Encrypt
* Launch tale, confirm access via https

Notes:
* GoDaddy API does support delete so DNS records must be manually removed after destroy