### PR TITLE
Added tale launching test to monitoring

### DIFF
--- a/stack.tf
+++ b/stack.tf
@@ -20,6 +20,18 @@ data "template_file" "stack" {
   }
 }
 
+data "template_file" "monitoring" {
+  template = "${file("${path.module}/stacks/monitoring/monitoring.tpl")}"
+
+  vars {
+    domain = "${var.domain}"
+    subdomain = "${var.subdomain}"
+    version = "${var.version}"
+    monitoring_api_key = "${var.monitoring_api_key}"
+    monitoring_tale_id = "${var.monitoring_tale_id}"
+  }
+}
+
 resource "null_resource" "label_nodes" {
   depends_on = ["null_resource.provision_slave", "null_resource.provision_fileserver"]
 
@@ -69,7 +81,7 @@ resource "null_resource" "deploy_stack" {
   }
 
   provisioner "file" {
-    source = "stacks/monitoring/monitoring.yaml"
+    content = "${data.template_file.monitoring.rendered}"
     destination = "/home/core/wholetale/monitoring.yaml"
   }
 

--- a/stacks/monitoring/monitoring.tpl
+++ b/stacks/monitoring/monitoring.tpl
@@ -7,7 +7,7 @@ networks:
 
 services:
   checkmk-agent:
-    image: wholetale/check_mk:latest
+    image: wholetale/check_mk:${version}
     networks:
       - outside
     volumes:
@@ -16,3 +16,6 @@ services:
       mode: global
     environment:
       - NAMESPACE=wt
+      - GIRDER_URL=https://girder.${subdomain}.${domain}
+      - GIRDER_API_KEY=${monitoring_api_key}
+      - TALE_ID=${monitoring_tale_id}

--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,13 @@ variable "version" {
    default = "latest"
    description = "Docker component versions"
 }
+
+variable "monitoring_api_key" {
+   default = ""
+   description = "Girder API key for monitoring"
+}
+
+variable "monitoring_tale_id" {
+   default = "59f0b91584b7920001b46f2e" 
+   description = "Tale ID used for monitoring (default production Ligo Tale)"
+}


### PR DESCRIPTION
Along with  https://github.com/whole-tale/check_mk/pull/2 fixes https://github.com/whole-tale/terraform_deployment/issues/7

* Added monitoring user API key and tale ID variables to variables.tf
* Modified monitoring stack to use image version and set environment variables required for tale test

The `wholetale/check_mk:ligo-test` image is currently running on staging with this configuration and the associated test setup in OMD