### PR TITLE
Set 'https' as a default entrypoint

### DIFF
--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -20,6 +20,7 @@ docker run \
     -e GIRDER_API_URL=https://girder.${domain}/api/v1 \
     -e HOSTDIR=/host \
     -e TRAEFIK_NETWORK=wt_traefik-net \
+    -e TRAEFIK_ENTRYPOINT=https \
     -e REGISTRY_USER=${registry_user} \
     -e REGISTRY_URL=https://registry.${domain} \
     -e REGISTRY_PASS=${registry_pass} \


### PR DESCRIPTION
As of https://github.com/whole-tale/gwvolman/commit/bb0ff115e08857eb3c6e4645203e85a70a488e44 entrypoint for `Instances` can now be set via env var.