### PR TITLE
Add a flag that gets set when the environment is development

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,8 @@ variable "dataone_url" {
    default = "https://dev.nceas.ucsb.edu/cn/v2"
    description = "DataONE member node URL"
 }
+
+variable "dashboard_dev" {
+   default = "false"
+   description = "Flag that represents whether this is a production environment"
+}


### PR DESCRIPTION
I added a variable to match up with the dev flag that's in deploy-dev, which is used in the dashboard. I set the default to `false`, since it would e a rare case to deploy via terraform on a dev environment.