### PR TITLE
enh: rotate girder container logs

### DIFF
--- a/stacks/core/swarm-compose.tpl
+++ b/stacks/core/swarm-compose.tpl
@@ -90,6 +90,12 @@ services:
     volumes:
       - "/mnt/homes:/tmp/data"
       - "/mnt/dms:/tmp/ps"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "10"
+        compress: "true"
     deploy:
       replicas: 1
       labels:


### PR DESCRIPTION
We don't do anything with those logs anyway, yet after short time (3mo):

```
$ docker ps --filter=name=girder
CONTAINER ID        IMAGE                     COMMAND                  CREATED             STATUS              PORTS               NAMES
d0095faddf5d        wholetale/girder:v0.9.1   "/usr/local/bin/dock…"   3 months ago        Up 3 months         8080/tcp            wt_girder.1.xaabvfh4v0txhbkcc8sq3w630
$ docker inspect --format={{.LogPath}} $(docker ps --filter=name=girder -q) | xargs ls -lh
-rw-r----- 1 root root 29G Apr  5 10:32 /var/lib/docker/containers/d0095faddf5d1103ff1af3865cecfe441afe0b9a536c743ffaf99a13acef0f52/d0095faddf5d1103ff1af3865cecfe441afe0b9a536c743ffaf99a13acef0f52-json.log
```