### PR TITLE
Use host 80/443 for proper X- headers

### DIFF
--- a/stacks/core/swarm-compose.tpl
+++ b/stacks/core/swarm-compose.tpl
@@ -18,8 +18,12 @@ services:
   traefik:
     image: traefik:v2.4
     ports:
-      - "80:80"
-      - "443:443"
+      - target: 80
+        published: 80
+        mode: host
+      - target: 443
+        published: 443
+        mode: host
       - "8080:8080"
     networks:
       - traefik-net


### PR DESCRIPTION
Fun read at: https://dockerswarm.rocks/traefik/#getting-the-client-ip

tl;dr If you need to read the client IP in your applications/stacks using the X-Forwarded-For or X-Real-IP headers provided by Traefik, you need to make Traefik listen directly, not through Docker Swarm mode, even while being deployed with Docker Swarm mode.

I swear one day we will actually aggregate our logs and this will become useful...